### PR TITLE
Update outout.tf

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -3,4 +3,5 @@ output "snowflake_svc_public_key" {
 }
 output "snowflake_svc_private_key" {
     value = tls_private_key.svc_key.private_key_pem
+    sensitive = true
 }


### PR DESCRIPTION
│ Error: Output refers to sensitive values
│
│   on outputs.tf line 4:
│    4: output "snowflake_svc_private_key" {
│
│ To reduce the risk of accidentally exporting sensitive data that was
│ intended to be only internal, Terraform requires that any root module
│ output containing sensitive data be explicitly marked as sensitive, to
│ confirm your intent.
│
│ If you do intend to export this data, annotate the output value as
│ sensitive by adding the following argument:
│     sensitive = true
